### PR TITLE
use ror.org instead of www.ror.org as baseurl

### DIFF
--- a/content/blog/2019-02-10-announcing-first-ror-prototype.md
+++ b/content/blog/2019-02-10-announcing-first-ror-prototype.md
@@ -136,7 +136,7 @@ To help guide the next stages of the project, we are putting out an open call fo
 
 For those who want to stay informed about the project but not necessarily be part of the advisory group, you have other options!
 
-- Sign up for our mailing list (via the footer at [ror.org](https://www.ror.org))
+- Sign up for our mailing list (via the footer at [ror.org](https://ror.org))
 
 - Join our community on Slack ([www.tinyurl.com/ror-community](http://www.tinyurl.com/ror-community)),
 

--- a/live.toml
+++ b/live.toml
@@ -1,6 +1,6 @@
 languageCode = "en-us"
 title = "ROR"
-baseurl = "https://www.ror.org/"
+baseurl = "https://ror.org/"
 style = "turquoise"
 theme = "hugo-ror"
 pluralizelisttitles = "false"


### PR DESCRIPTION
The ROR website is hosted at ror.org, requests to www.ror.org redirect there. We should thus use ror.org as baseurl.