### PR TITLE
Enlarges integrations page Airtable embed

### DIFF
--- a/content/integrations/_index.md
+++ b/content/integrations/_index.md
@@ -14,4 +14,4 @@ Working on a ROR integration? Let us know via [this form](https://airtable.com/s
 
 # Active ROR Integrations
 
-<iframe class="airtable-embed" src="https://airtable.com/embed/shr7a3O7xPb4y8xhx?backgroundColor=gray&viewControls=on" frameborder="0" onmousewheel="" width="100%" height="533" style="background: transparent; border: 1px solid #ccc;"></iframe>
+<iframe class="airtable-embed" src="https://airtable.com/embed/shr7a3O7xPb4y8xhx?backgroundColor=gray&viewControls=on" frameborder="0" onmousewheel="" width="100%" height="2000" style="background: transparent; border: 1px solid #ccc;"></iframe>


### PR DESCRIPTION
Mostly just practicing updating the ROR site, but I would actually also like to make the Airtable embed on /integrations longer so that it shows more records on the page