### PR TITLE
Changes Support to Documentation

### DIFF
--- a/data/socials/7.yaml
+++ b/data/socials/7.yaml
@@ -1,3 +1,3 @@
-icon: "fa-solid fa-life-ring"
-title: "Support"
+icon: "fa-solid fa-book"
+title: "Documentation"
 link: "https://ror.readme.io/"

--- a/themes/hugo-ror/assets/sass/partials/_hugo-ror.scss
+++ b/themes/hugo-ror/assets/sass/partials/_hugo-ror.scss
@@ -6379,7 +6379,7 @@ img {
     margin: 0;
 }
 .navbar-nav .nav-item:not(:last-child) {
-    margin-right: 5px;
+    margin-right: 15px;
 }
 .navbar-collapse:not(.has-image) {
     background: 0 0!important;

--- a/themes/hugo-ror/layouts/partials/nav.html
+++ b/themes/hugo-ror/layouts/partials/nav.html
@@ -34,7 +34,7 @@
           </li>
           <li class="nav-item">
             <a class="nav-link external" href="https://ror.readme.io/">
-              <p>Support <i class="fa-solid fa-external-link"></i></p>
+              <p>Documentation <i class="fa-solid fa-external-link"></i></p>
             </a>
           </li>
         </ul>

--- a/themes/hugo-ror/layouts/partials/socials.html
+++ b/themes/hugo-ror/layouts/partials/socials.html
@@ -5,7 +5,7 @@
   <div class="container">
 	<div class="row justify-content-between no-gutters ml-auto mr-auto text-center">
 		{{ range sort .Site.Data.socials }}
-		<div class=" col-sm-6 col-md-1 ">
+		<div class=" col-sm-6 col-md-auto ">
 			<a href="{{ .link }}">
 			 <a {{ if .rel }}rel='{{.rel}}'{{ end }} href='{{ .link }}'>
 				 <i class="{{ .icon }}"></i>

--- a/themes/hugo-ror/layouts/partials/socials.html
+++ b/themes/hugo-ror/layouts/partials/socials.html
@@ -3,9 +3,9 @@
 {{ if gt (len .Site.Data.socials) 0 }}
 <section class="section section-socials" data-background-color="light-grey">
   <div class="container">
-	<div class="row justify-content-between no-gutters ml-auto mr-auto text-center">
+	<div class="row justify-content-between ml-auto mr-auto text-center ">
 		{{ range sort .Site.Data.socials }}
-		<div class=" col-sm-6 col-md-auto ">
+		<div class=" col-sm-6 col-md">
 			<a href="{{ .link }}">
 			 <a {{ if .rel }}rel='{{.rel}}'{{ end }} href='{{ .link }}'>
 				 <i class="{{ .icon }}"></i>

--- a/themes/hugo-ror/layouts/partials/socials.html
+++ b/themes/hugo-ror/layouts/partials/socials.html
@@ -3,7 +3,7 @@
 {{ if gt (len .Site.Data.socials) 0 }}
 <section class="section section-socials" data-background-color="light-grey">
   <div class="container">
-	<div class="row justify-content-between ml-auto mr-auto text-center ">
+	<div class="row justify-content-between no-gutters ml-auto mr-auto text-center ">
 		{{ range sort .Site.Data.socials }}
 		<div class=" col-sm-6 col-md">
 			<a href="{{ .link }}">


### PR DESCRIPTION
Changes "Support" to "Documentation" in the header and footer. 
<img width="1301" alt="Screenshot 2023-02-27 at 6 09 11 AM" src="https://user-images.githubusercontent.com/227453/221549475-899a34ce-4cfa-4882-b5ba-6dc508454d90.png">
<img width="808" alt="Screenshot 2023-02-27 at 6 08 59 AM" src="https://user-images.githubusercontent.com/227453/221549481-4ac784b2-fea1-4a00-a5ab-701eeb79240c.png">
