### PR TITLE
Add ROR API outage announcement banner

### DIFF
--- a/data/announcement/announcement.yaml
+++ b/data/announcement/announcement.yaml
@@ -1,2 +1,2 @@
-announcement_text: "Register now for the ROR Annual Community Meeting, February 3-4, 2026!"
-announcement_url: "https://ror.org/events/"
+announcement_text: "The ROR API is currently experiencing an outage. We are working to restore service as quickly as possible."
+announcement_url: ""

--- a/dev.toml
+++ b/dev.toml
@@ -69,7 +69,7 @@ enableGitInfo = true
     enable = true
 
 [params.announcement]
-    enable = false 
+    enable = true 
 
 [params.homepage_features]
     enable = true

--- a/live.toml
+++ b/live.toml
@@ -69,7 +69,7 @@ enableGitInfo = true
     enable = true
 
 [params.announcement]
-    enable = false 
+    enable = true 
 
 [params.homepage_features]
     enable = true

--- a/localhost.toml
+++ b/localhost.toml
@@ -69,7 +69,7 @@ enableGitInfo = true
     enable = true
 
 [params.announcement]
-    enable = false 
+    enable = true 
 
 [params.homepage_features]
     enable = true

--- a/staging.toml
+++ b/staging.toml
@@ -69,7 +69,7 @@ enableGitInfo = true
     enable = true
 
 [params.announcement]
-    enable = false 
+    enable = true 
 
 [params.homepage_features]
     enable = true

--- a/themes/hugo-ror/assets/sass/partials/_hugo-ror.scss
+++ b/themes/hugo-ror/assets/sass/partials/_hugo-ror.scss
@@ -7075,8 +7075,9 @@ $desktop-width: 1024px;
 	padding: 1.5em 0 0 0;
 }
 
+.section-announcement p,
 .section-announcement p a {
-	color:#FFF;
+	color: $black;
 	font-size:1.75rem;
 }
 

--- a/themes/hugo-ror/layouts/partials/announcement.html
+++ b/themes/hugo-ror/layouts/partials/announcement.html
@@ -1,7 +1,7 @@
 {{ if isset .Site.Params "announcement" }}
 {{ if .Site.Params.announcement.enable }}
 {{ if gt (len .Site.Data.announcement) 0 }}
-<section id="announcement" class="section section-announcement" data-background-color="purple">
+<section id="announcement" class="section section-announcement" data-background-color="orange">
   <div class="container">
     {{ range sort .Site.Data.announcement }}
     <div class="row">

--- a/themes/hugo-ror/layouts/partials/announcement.html
+++ b/themes/hugo-ror/layouts/partials/announcement.html
@@ -6,7 +6,7 @@
     {{ range sort .Site.Data.announcement }}
     <div class="row">
       <div class="col-md-12 ml-auto mr-auto text-center">
-        <p><a href="{{ .announcement_url }}">{{ .announcement_text }}</a></p>
+        <p>{{ if .announcement_url }}<a href="{{ .announcement_url }}">{{ .announcement_text }}</a>{{ else }}{{ .announcement_text }}{{ end }}</p>
       </div>
     </div>
     {{ end }}


### PR DESCRIPTION
## Summary
Adds an announcement banner notifying users that the ROR API is currently experiencing an outage. This is a banner-only change cherry-picked onto `master` so it can ship to production without pulling in the unrelated backlog of commits sitting in `dev`/`staging`.

## Changes
- **`data/announcement/announcement.yaml`** — outage notice text; `announcement_url` left empty (text-only).
- **`themes/hugo-ror/layouts/partials/announcement.html`** — banner switched to `data-background-color="orange"`; renders the link only when a URL is set (so empty URL shows clean text, not a self-link).
- **`themes/hugo-ror/assets/sass/partials/_hugo-ror.scss`** — banner text set to `$black` (`#293030`) for contrast on the orange background.
- **`dev.toml` / `live.toml` / `localhost.toml` / `staging.toml`** — `[params.announcement] enable = true`.

## Verified
- `hugo` build passes; compiled CSS confirms `#e89005` orange background with `#293030` black text on the banner.

## Note
Once the outage is resolved, revert this (or flip `enable` back to `false`) to remove the banner.