### PR TITLE
Disable announcement banner after API outage resolved

### DIFF
--- a/dev.toml
+++ b/dev.toml
@@ -69,7 +69,7 @@ enableGitInfo = true
     enable = true
 
 [params.announcement]
-    enable = true 
+    enable = false 
 
 [params.homepage_features]
     enable = true

--- a/live.toml
+++ b/live.toml
@@ -69,7 +69,7 @@ enableGitInfo = true
     enable = true
 
 [params.announcement]
-    enable = true 
+    enable = false 
 
 [params.homepage_features]
     enable = true

--- a/localhost.toml
+++ b/localhost.toml
@@ -69,7 +69,7 @@ enableGitInfo = true
     enable = true
 
 [params.announcement]
-    enable = true 
+    enable = false 
 
 [params.homepage_features]
     enable = true

--- a/staging.toml
+++ b/staging.toml
@@ -69,7 +69,7 @@ enableGitInfo = true
     enable = true
 
 [params.announcement]
-    enable = true 
+    enable = false 
 
 [params.homepage_features]
     enable = true


### PR DESCRIPTION
Removes outage announcement banner down by flipping `[params.announcement] enable` back to `false` in all four environment configs.