### PR TITLE
Reverts announcement banner to purple but keeps conditional logic

### DIFF
--- a/localhost.toml
+++ b/localhost.toml
@@ -69,7 +69,7 @@ enableGitInfo = true
     enable = true
 
 [params.announcement]
-    enable = false 
+    enable = true 
 
 [params.homepage_features]
     enable = true

--- a/themes/hugo-ror/assets/sass/partials/_hugo-ror.scss
+++ b/themes/hugo-ror/assets/sass/partials/_hugo-ror.scss
@@ -7077,7 +7077,7 @@ $desktop-width: 1024px;
 
 .section-announcement p,
 .section-announcement p a {
-	color: $black;
+	color: #FFF;
 	font-size:1.75rem;
 }
 

--- a/themes/hugo-ror/layouts/partials/announcement.html
+++ b/themes/hugo-ror/layouts/partials/announcement.html
@@ -1,7 +1,7 @@
 {{ if isset .Site.Params "announcement" }}
 {{ if .Site.Params.announcement.enable }}
 {{ if gt (len .Site.Data.announcement) 0 }}
-<section id="announcement" class="section section-announcement" data-background-color="orange">
+<section id="announcement" class="section section-announcement" data-background-color="purple">
   <div class="container">
     {{ range sort .Site.Data.announcement }}
     <div class="row">


### PR DESCRIPTION
This change allows the announcement banner to function without a link. Announcement text will be white on a purple banner. If a link is added in announcement.yaml, the link will be white, bold, and underlined on hover. 