### PR TITLE
Centralize S3 Deployment and CloudFront Invalidation in a Composite Action

### DIFF
--- a/.github/actions/deploy-s3/action.yml
+++ b/.github/actions/deploy-s3/action.yml
@@ -1,0 +1,31 @@
+name: Deploy to S3
+description: Sync a folder to S3 and invalidate a CloudFront distribution
+
+inputs:
+  folder:
+    description: Local directory to sync
+    required: false
+    default: public
+  bucket:
+    description: Destination S3 bucket name
+    required: true
+  bucket-region:
+    description: AWS region of the S3 bucket
+    required: true
+  dist-id:
+    description: CloudFront distribution ID to invalidate
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Sync to S3 and invalidate CloudFront
+      env:
+        FOLDER: ${{ inputs.folder }}
+        BUCKET: ${{ inputs.bucket }}
+        BUCKET_REGION: ${{ inputs.bucket-region }}
+        DIST_ID: ${{ inputs.dist-id }}
+      shell: bash
+      run: |
+        aws s3 sync "${FOLDER}/" "s3://${BUCKET}/" --region "${BUCKET_REGION}" --delete
+        aws cloudfront create-invalidation --distribution-id "${DIST_ID}" --paths "/*"

--- a/.github/workflows/dev.yml
+++ b/.github/workflows/dev.yml
@@ -11,8 +11,6 @@ jobs:
     env:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      S3_BUCKET: ${{ secrets.S3_BUCKET_DEV }}
-      CLOUDFRONT_DISTRIBUTION_ID: ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID_DEV }}
     steps:
       - uses: actions/checkout@v7
         with:
@@ -25,14 +23,11 @@ jobs:
           config: dev.toml
 
       - name: Deploy
-        uses: reggionick/s3-deploy@v4
+        uses: ./.github/actions/deploy-s3
         with:
-          folder: public
           bucket: ${{ secrets.S3_BUCKET_DEV }}
           bucket-region: ${{ secrets.S3_BUCKET_REGION }}
           dist-id: ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID_DEV }}
-          invalidation: /*
-          delete-removed: true
 
       - name: Notify Slack
         if: always()

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -11,8 +11,6 @@ jobs:
     env:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      S3_BUCKET: ${{ secrets.S3_BUCKET }}
-      CLOUDFRONT_DISTRIBUTION_ID: ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }}
     steps:
       - uses: actions/checkout@v7
         with:
@@ -25,14 +23,11 @@ jobs:
           config: live.toml
 
       - name: Deploy
-        uses: reggionick/s3-deploy@v4
+        uses: ./.github/actions/deploy-s3
         with:
-          folder: public
           bucket: ${{ secrets.S3_BUCKET }}
           bucket-region: ${{ secrets.S3_BUCKET_REGION }}
           dist-id: ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID }}
-          invalidation: /*
-          delete-removed: true
 
       - name: Notify Slack
         if: always()

--- a/.github/workflows/staging.yml
+++ b/.github/workflows/staging.yml
@@ -11,8 +11,6 @@ jobs:
     env:
       AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      S3_BUCKET: ${{ secrets.S3_BUCKET_STAGING }}
-      CLOUDFRONT_DISTRIBUTION_ID: ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID_STAGING }}
     steps:
       - uses: actions/checkout@v7
         with:
@@ -25,14 +23,11 @@ jobs:
           config: staging.toml
 
       - name: Deploy
-        uses: reggionick/s3-deploy@v4
+        uses: ./.github/actions/deploy-s3
         with:
-          folder: public
           bucket: ${{ secrets.S3_BUCKET_STAGING }}
           bucket-region: ${{ secrets.S3_BUCKET_REGION }}
           dist-id: ${{ secrets.CLOUDFRONT_DISTRIBUTION_ID_STAGING }}
-          invalidation: /*
-          delete-removed: true
 
       - name: Notify Slack
         if: always()


### PR DESCRIPTION
## Purpose

Centralize S3 deployment and CloudFront invalidation in a repository-owned GitHub composite action. This replaces the external `reggionick/s3-deploy` action across development, staging, and production workflows.

## Approach

A new local `deploy-s3` composite action performs the deployment using the AWS CLI. Each environment workflow now invokes this shared action with its environment-specific bucket and CloudFront distribution settings.

### Key Modifications

- Added `.github/actions/deploy-s3/action.yml`.
- Replaced `reggionick/s3-deploy@v4` in:
  - `dev.yml`
  - `staging.yml`
  - `master.yml`
- Removed redundant S3 bucket and CloudFront distribution environment variables from the workflows.
- Retained environment-specific secrets as action inputs.
- Preserved Slack notification behavior after deployment.

### Important Technical Details

- Syncs the `public/` directory by default to the configured S3 bucket.
- Uses `aws s3 sync` with:
  - The provided AWS region.
  - `--delete` to remove files no longer present in the local directory.
- Invalidates all CloudFront paths using `/*` after synchronization.
- The action supports a configurable source folder through the optional `folder` input.
- AWS credentials continue to be provided through `AWS_ACCESS_KEY_ID` and `AWS_SECRET_ACCESS_KEY` workflow environment variables.
- The runner must have the AWS CLI installed and configured with permissions to sync the target bucket and create CloudFront invalidations.

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Reviewer, please remember our [guidelines](https://datacite.atlassian.net/wiki/spaces/TEC/pages/1168375809/Pull+Request+Guidelines):

- Be humble in the language and feedback you give, ask don't tell.
- Consider using positive language as opposed to neutral language when offering feedback. This is to avoid the negative bias that can occur with neutral language appearing negative.
- Offer suggestions on how to improve code e.g. simplification or expanding clarity.
- Ensure you give reasons for the changes you are proposing.